### PR TITLE
Make profile config optional

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = "utf-8"
+indent_style = space
+indent_size = 4
+
+[**{package.json}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 build/
 *.zip
 .idea
+/coverage

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+    "latedef": true,
+    "undef": true,
+    "unused": "vars",
+    "node": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "4"
+  - "0.12"
+  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "4"
   - "0.12"
   - "0.10"
+after_success:
+  - ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/iofjuupasli/node-setty.svg?branch=master)](https://travis-ci.org/iofjuupasli/node-setty)
 [![Coverage Status](https://img.shields.io/coveralls/iofjuupasli/node-setty.svg)](https://coveralls.io/r/iofjuupasli/node-setty?branch=master)
+[![Code Climate](https://codeclimate.com/github/iofjuupasli/node-setty/badges/gpa.svg)](https://codeclimate.com/github/iofjuupasli/node-setty)
 
 Key/value configuration management
 ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Key/value configuration management
---
+---
 
 Setty is a small node configuration util, which help better manage key/value settings across different environments.
 Depends on [nconf](https://github.com/flatiron/nconf).
@@ -17,13 +17,13 @@ npm install setty --save-dev
 var setty = require('setty');
 var path = require('path');
 
-setty.load({
-      profileEnv: 'SETTY_PROFILE',
-      profile: '.config', // Default value
-      configFileName: 'config.json', // Default value
-      settingsDir: path.join(__dirname, 'settings')
-    });
-    
+setty({
+  profileEnv: 'SETTY_PROFILE', // Default value
+  profile: '.config', // Default value
+  configFileName: 'config.json', // Default value
+  settingsDir: path.join(process.cwd(), './config/settings') // Default value
+});
+
 //Reading settings
 var connection = setty.get('connection');
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Depends on [nconf](https://github.com/flatiron/nconf).
 ## Installation
 
 Installing the module
-```
+```sh
 npm install setty --save-dev
 ```
 
 ## Usage exampple:
 
-```
+```js
 var setty = require('setty');
 var path = require('path');
 
@@ -60,6 +60,6 @@ settings
 
 ## Running tests
 
-```
+```sh
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/iofjuupasli/node-setty.svg?branch=master)](https://travis-ci.org/iofjuupasli/node-setty)
+[![Coverage Status](https://img.shields.io/coveralls/iofjuupasli/node-setty.svg)](https://coveralls.io/r/iofjuupasli/node-setty?branch=master)
+
 Key/value configuration management
 ---
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,11 +34,11 @@ Setty.prototype.configure = function(cfg){
   var envProfilePath = process.env[cfg.profileEnv];
 
   if (!fs.existsSync(cfg.profileFilePath) && !envProfilePath) {
-    throw new Error(['Make sure that profile file "', cfg.profile, '" exists in the following dir: ', cfg.settingsDir + ' or specified in the environment variable: ' + cfg.profileEnv].join(''));
+    return;
   }
 
   cfg.profilePath = envProfilePath || fs.readFileSync(cfg.profileFilePath, 'utf8').trim();
-  cfg.userConfigPath =  path.join(cfg.settingsDir, cfg.profilePath, cfg.configFileName);
+  cfg.userConfigPath = path.join(cfg.settingsDir, cfg.profilePath, cfg.configFileName);
 
   if (!fs.existsSync(cfg.userConfigPath)) {
     var err = util.format('User config file does not exists at "%s". ' +
@@ -46,21 +46,21 @@ Setty.prototype.configure = function(cfg){
 
     throw new Error(err);
   }
-
-  nconf.clear();
 };
 
 Setty.prototype.load = function(cfg){
   this.configure(cfg);
 
+  nconf.reset();
   //Load environment variables
   //https://github.com/flatiron/nconf#env
   nconf.env();
-  nconf.file('user', this.config.userConfigPath);
+  if (this.config.userConfigPath){
+    nconf.file('user', this.config.userConfigPath);
+  }
   nconf.file('default', this.config.rootConfigPath);
 };
 
 Setty.prototype.get = function(name){
   return nconf.get(name);
 };
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,66 +1,33 @@
-var _ = require('underscore');
-var nconf = require('nconf');
 var util = require('util');
 var path = require('path');
 var fs = require('fs');
 
-var setty = new Setty();
-exports = module.exports = setty;
+var nconf = require('nconf');
+var depd = require('depd')('setty');
 
-function Setty(){
-  this.config = null;
+function Setty(cfg) {
+    nconf.reset();
+    nconf.env();
+    var settingsDir = cfg.settingsDir || path.join(process.cwd(), './config/settings');
+    fs.accessSync(settingsDir);
+    var profile = process.env[cfg.profileEnv || 'SETTY_PROFILE'];
+    if (!profile) {
+        try {
+            profile = fs.readFileSync(path.join(settingsDir, cfg.profile || '.config'), 'utf8').trim();
+        } catch (e) {}
+    }
+    var configFileName = cfg.configFileName || 'config.json';
+    if (profile) {
+        var userConfigPath = path.join(settingsDir, profile, configFileName);
+        fs.accessSync(userConfigPath);
+        nconf.file('user', userConfigPath);
+    } else if (cfg.strict) {
+        throw new Error('user config required but not found');
+    }
+    var defaultConfigPath = path.join(settingsDir, configFileName);
+    nconf.file('default', defaultConfigPath);
 }
 
-Setty.prototype.configure = function(cfg){
-  _.defaults(cfg, {
-    profile: '.config',
-    //Setty will check this environment variable before failing if profile file is not found
-    profileEnv: 'SETTY_PROFILE',
-    configFileName: 'config.json',
-    settingsDir: null
-  });
-  this.config = cfg;
-
-  if (!fs.existsSync(cfg.settingsDir)) {
-    throw new Error('Make sure that settings directory exists.');
-  }
-  cfg.profileFilePath = path.join(cfg.settingsDir, cfg.profile);
-  cfg.rootConfigPath = path.join(cfg.settingsDir, cfg.configFileName);
-
-  if (!fs.existsSync(cfg.rootConfigPath)) {
-    throw new Error(['Make sure that root config "', cfg.configFileName, '" exists in the following dir: ', cfg.settingsDir].join(''));
-  }
-
-  var envProfilePath = process.env[cfg.profileEnv];
-
-  if (!fs.existsSync(cfg.profileFilePath) && !envProfilePath) {
-    return;
-  }
-
-  cfg.profilePath = envProfilePath || fs.readFileSync(cfg.profileFilePath, 'utf8').trim();
-  cfg.userConfigPath = path.join(cfg.settingsDir, cfg.profilePath, cfg.configFileName);
-
-  if (!fs.existsSync(cfg.userConfigPath)) {
-    var err = util.format('User config file does not exists at "%s". ' +
-      'Make sure that profile file "%s" point to the user config. ', cfg.userConfigPath, cfg.profile);
-
-    throw new Error(err);
-  }
-};
-
-Setty.prototype.load = function(cfg){
-  this.configure(cfg);
-
-  nconf.reset();
-  //Load environment variables
-  //https://github.com/flatiron/nconf#env
-  nconf.env();
-  if (this.config.userConfigPath){
-    nconf.file('user', this.config.userConfigPath);
-  }
-  nconf.file('default', this.config.rootConfigPath);
-};
-
-Setty.prototype.get = function(name){
-  return nconf.get(name);
-};
+module.exports = Setty;
+module.exports.get = nconf.get.bind(nconf);
+module.exports.load = depd.function(Setty, 'load');

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,18 +8,25 @@ var depd = require('depd')('setty');
 function Setty(cfg) {
     nconf.reset();
     nconf.env();
-    var settingsDir = cfg.settingsDir || path.join(process.cwd(), './config/settings');
-    fs.accessSync(settingsDir);
+    var settingsDir = cfg.settingsDir ||
+        path.join(process.cwd(), './config/settings');
+    if (!fs.existsSync(settingsDir)) {
+        throw new Error('setty directory not found: ' + settingsDir);
+    }
     var profile = process.env[cfg.profileEnv || 'SETTY_PROFILE'];
     if (!profile) {
         try {
-            profile = fs.readFileSync(path.join(settingsDir, cfg.profile || '.config'), 'utf8').trim();
+            profile = fs.readFileSync(
+                path.join(settingsDir, cfg.profile || '.config'), 'utf8'
+            ).trim();
         } catch (e) {}
     }
     var configFileName = cfg.configFileName || 'config.json';
     if (profile) {
         var userConfigPath = path.join(settingsDir, profile, configFileName);
-        fs.accessSync(userConfigPath);
+        if (!fs.existsSync(userConfigPath)) {
+            throw new Error('setty config not found: ' + userConfigPath);
+        }
         nconf.file('user', userConfigPath);
     } else if (cfg.strict) {
         throw new Error('user config required but not found');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,19 @@
-var util = require('util');
 var path = require('path');
 var fs = require('fs');
 
 var nconf = require('nconf');
 var depd = require('depd')('setty');
 
-function Setty(cfg) {
-    nconf.reset();
-    nconf.env();
+function getSettingsDir(cfg) {
     var settingsDir = cfg.settingsDir ||
         path.join(process.cwd(), './config/settings');
     if (!fs.existsSync(settingsDir)) {
         throw new Error('setty directory not found: ' + settingsDir);
     }
+    return settingsDir;
+}
+
+function getProfileName(cfg, settingsDir) {
     var profile = process.env[cfg.profileEnv || 'SETTY_PROFILE'];
     if (!profile) {
         try {
@@ -21,18 +22,34 @@ function Setty(cfg) {
             ).trim();
         } catch (e) {}
     }
+    return profile;
+}
+
+function importProfileConfig(settingsDir, profile, configFileName) {
+    var userConfigPath = path.join(settingsDir, profile, configFileName);
+    if (!fs.existsSync(userConfigPath)) {
+        throw new Error('setty config not found: ' + userConfigPath);
+    }
+    nconf.file('user', userConfigPath);
+}
+
+function importDefaultConfig(settingsDir, configFileName) {
+    var defaultConfigPath = path.join(settingsDir, configFileName);
+    nconf.file('default', defaultConfigPath);
+}
+
+function Setty(cfg) {
+    nconf.reset();
+    nconf.env();
+    var settingsDir = getSettingsDir(cfg);
+    var profile = getProfileName(cfg, settingsDir);
     var configFileName = cfg.configFileName || 'config.json';
     if (profile) {
-        var userConfigPath = path.join(settingsDir, profile, configFileName);
-        if (!fs.existsSync(userConfigPath)) {
-            throw new Error('setty config not found: ' + userConfigPath);
-        }
-        nconf.file('user', userConfigPath);
+        importProfileConfig(settingsDir, profile, configFileName);
     } else if (cfg.strict) {
         throw new Error('user config required but not found');
     }
-    var defaultConfigPath = path.join(settingsDir, configFileName);
-    nconf.file('default', defaultConfigPath);
+    importDefaultConfig(settingsDir, configFileName);
 }
 
 module.exports = Setty;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/anorsich/node-setty",
   "dependencies": {
     "depd": "^1.1.0",
-    "nconf": "^0.7.1"
+    "nconf": "^0.8.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setty",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Configs management application",
   "main": "lib/index.js",
   "scripts": {
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/anorsich/node-setty",
   "dependencies": {
-    "nconf": "^0.7.1",
-    "underscore": "^1.7.0"
+    "depd": "^1.1.0",
+    "nconf": "^0.7.1"
   },
   "devDependencies": {
     "mocha": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Configs management application",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha test/test"
+    "test": "istanbul test _mocha"
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,9 @@
     "nconf": "^0.8.0"
   },
   "devDependencies": {
-    "mocha": "^2.1.0"
+    "coveralls": "^2.11.4",
+    "istanbul": "^0.3.20",
+    "mocha": "^2.1.0",
+    "mocha-lcov-reporter": "0.0.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,53 +2,65 @@ var assert = require('assert');
 var setty = require('..');
 var path = require('path');
 
-describe('Setty', function() {
-  it('should load and merge user and default settings', function(){
+describe('Setty', function () {
+    it('should load and merge user and default settings', function () {
+        setty({
+            profile: '.config',
+            configFileName: 'config.json',
+            settingsDir: path.join(__dirname, 'settings')
+        });
 
-    setty({
-      profile: '.config',
-      configFileName: 'config.json',
-      settingsDir: path.join(__dirname, 'settings')
+        assert.equal(setty.get('connection'), "Andrew's connection");
     });
 
-    assert.equal(setty.get('connection'), "Andrew's connection");
-  });
-
-  it('throw an error if settingsDir is not specified or does not exists', function(){
-    assert.throws(setty);
-  });
-
-  it('throw an error if root config file does not exists', function(){
-    assert.throws(setty.bind(null, {configFileName: 'not-exists.json'}));
-  });
-
-  it('should load profile from environment variable', function(){
-
-    process.env['SETTY_PROFILE1'] = 'andrew';
-    setty({
-      profileEnv: 'SETTY_PROFILE1',
-      profile: '.not-exists',
-      configFileName: 'config.json',
-      settingsDir: path.join(__dirname, 'settings')
+    it('throw an error if settingsDir is not specified or does not exists', function () {
+        assert.throws(setty);
     });
 
-    assert.equal(setty.get('connection'), "Andrew's connection");
-    process.env['SETTY_PROFILE1'] = undefined;
-  });
-
-  it('should use only defaults if profile not specified', function (){
-    setty({
-        settingsDir: path.join(__dirname, 'settings'),
-        profile: '.not-exists'
+    it('throw an error if root config file does not exists', function () {
+        assert.throws(setty.bind(null, {
+            configFileName: 'not-exists.json',
+            settingsDir: path.join(__dirname, 'settings')
+        }));
     });
-    assert.equal(setty.get('connection'), 'Default');
-  });
 
-  it('should throw in strict if profile config not exists', function (){
-    assert.throws(setty.bind(null, {
-        settingsDir: path.join(__dirname, 'settings'),
-        profile: '.not-exists',
-        strict: true
-    }));
-  });
+    it('should load profile from environment variable', function () {
+        var envKey = 'SETTY_PROFILE1';
+        process.env[envKey] = 'andrew';
+        setty({
+            profileEnv: 'SETTY_PROFILE1',
+            profile: '.not-exists',
+            configFileName: 'config.json',
+            settingsDir: path.join(__dirname, 'settings')
+        });
+
+        assert.equal(setty.get('connection'), "Andrew's connection");
+        process.env[envKey] = undefined;
+    });
+
+    it('should use only defaults if profile not specified', function () {
+        setty({
+            settingsDir: path.join(__dirname, 'settings'),
+            profile: '.not-exists'
+        });
+        assert.equal(setty.get('connection'), 'Default');
+    });
+
+    it('should throw in strict if profile config not exists', function () {
+        assert.throws(setty.bind(null, {
+            settingsDir: path.join(__dirname, 'settings'),
+            profile: '.not-exists',
+            strict: true
+        }));
+    });
+
+    it('should works with deprecated method', function () {
+        setty.load({
+            profile: '.config',
+            configFileName: 'config.json',
+            settingsDir: path.join(__dirname, 'settings')
+        });
+
+        assert.equal(setty.get('connection'), "Andrew's connection");
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+/*jshint mocha:true*/
 var assert = require('assert');
 var setty = require('..');
 var path = require('path');

--- a/test/test.js
+++ b/test/test.js
@@ -37,5 +37,14 @@ describe('Setty', function() {
     });
 
     assert.equal(setty.get('connection'), "Andrew's connection");
+    process.env['SETTY_PROFILE1'] = undefined;
+  });
+
+  it('should use only defaults if profile not specified', function (){
+    setty.load({
+        settingsDir: path.join(__dirname, 'settings'),
+        profile: '.not-exists'
+    });
+    assert.equal(setty.get('connection'), 'Default');
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ var path = require('path');
 describe('Setty', function() {
   it('should load and merge user and default settings', function(){
 
-    setty.load({
+    setty({
       profile: '.config',
       configFileName: 'config.json',
       settingsDir: path.join(__dirname, 'settings')
@@ -15,21 +15,17 @@ describe('Setty', function() {
   });
 
   it('throw an error if settingsDir is not specified or does not exists', function(){
-    assert.throws(setty.load);
-  });
-
-  it('throw an error if profile does not exists', function(){
-    assert.throws(setty.load.bind(null, {profile: '.not-exists'}));
+    assert.throws(setty);
   });
 
   it('throw an error if root config file does not exists', function(){
-    assert.throws(setty.load.bind(null, {configFileName: 'not-exists.json'}));
+    assert.throws(setty.bind(null, {configFileName: 'not-exists.json'}));
   });
 
   it('should load profile from environment variable', function(){
 
     process.env['SETTY_PROFILE1'] = 'andrew';
-    setty.load({
+    setty({
       profileEnv: 'SETTY_PROFILE1',
       profile: '.not-exists',
       configFileName: 'config.json',
@@ -41,10 +37,18 @@ describe('Setty', function() {
   });
 
   it('should use only defaults if profile not specified', function (){
-    setty.load({
+    setty({
         settingsDir: path.join(__dirname, 'settings'),
         profile: '.not-exists'
     });
     assert.equal(setty.get('connection'), 'Default');
+  });
+
+  it('should throw in strict if profile config not exists', function (){
+    assert.throws(setty.bind(null, {
+        settingsDir: path.join(__dirname, 'settings'),
+        profile: '.not-exists',
+        strict: true
+    }));
   });
 });


### PR DESCRIPTION
Now if profile config not provided it uses only default config without throwing error.

Also simpified API, with backward compatibility.
- `()` instead `.load()`
- `path.join(process.cwd(), './config/settings')` as default `settingsDir`

Fixed resetting - nconf uses `reset` for cleaning all current loaded configs, not `clear`.

Added some service integrations - travis ci, coveralls, codeclimate
